### PR TITLE
fix: change brand name from `github` to `GitHub`

### DIFF
--- a/Website/src/index.ejs
+++ b/Website/src/index.ejs
@@ -146,7 +146,7 @@
         platform of choice.
       </p>
       <a class="white-button" href="https://github.com/woltapp/blurhash">
-        More on github
+        More on GitHub
       </a>
     </div>
   </body>


### PR DESCRIPTION
- Change brand name from `github` to `GitHub` on the website