### PR TITLE
Provide a ES module entry point, mark package as side-effect free

### DIFF
--- a/TypeScript/package.json
+++ b/TypeScript/package.json
@@ -3,6 +3,7 @@
   "version": "1.1.3",
   "description": "Encoder and decoder for the Wolt BlurHash algorithm.",
   "main": "dist/index.js",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
@@ -11,12 +12,13 @@
   "homepage": "http://blurhash.com",
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "npm run ts",
+    "build": "npm run ts && npm run ts:esm",
     "demo": "webpack-dev-server --mode development",
     "prettier": "prettier src/**/*.ts",
     "prettier-fix": "npm run prettier -- --write",
     "ts": "tsc",
-    "ts:watch": "npm run ts -- --noEmit --watch"
+    "ts:watch": "npm run ts -- --noEmit --watch",
+    "ts:esm": "tsc --outDir dist/esm --target es2020 --declaration false --module es2015"
   },
   "keywords": [
     "blurhash",

--- a/TypeScript/package.json
+++ b/TypeScript/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/woltapp/blurhash/tree/master/TypeScript"


### PR DESCRIPTION
The ES module output is placed into dist/esm/ (ie. dist/esm/index.js is the entry point).