### PR TITLE
Kotlin: Experimental. Benchmark for coroutines (decoding with parallel tasks)

### DIFF
--- a/Kotlin/demo/build.gradle
+++ b/Kotlin/demo/build.gradle
@@ -26,4 +26,6 @@ android {
 dependencies {
     implementation project(path: ':lib')
     implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.2.0'
 }

--- a/Kotlin/demo/build.gradle
+++ b/Kotlin/demo/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "com.wolt.blurhash"
-        minSdkVersion 14
+        minSdkVersion 17
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
+++ b/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
@@ -1,12 +1,13 @@
 package com.wolt.blurhashapp
 
 import android.os.Bundle
+import android.os.SystemClock
 import android.view.View
 import android.widget.EditText
 import android.widget.ImageView
-import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import com.wolt.blurhashkt.BlurHashDecoder
+import kotlinx.android.synthetic.main.activity_main.*
 
 class MainActivity : AppCompatActivity() {
 
@@ -16,8 +17,11 @@ class MainActivity : AppCompatActivity() {
         val etInput: EditText = findViewById(R.id.etInput)
         val ivResult: ImageView = findViewById(R.id.ivResult)
         findViewById<View>(R.id.tvDecode).setOnClickListener {
+            val start = SystemClock.elapsedRealtime()
             val bitmap = BlurHashDecoder.decode(etInput.text.toString(), 20, 12)
+            val time = SystemClock.elapsedRealtime() - start
             ivResult.setImageBitmap(bitmap)
+            ivResultMs.text = "Decode time: $time ms"
         }
     }
 

--- a/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
+++ b/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
@@ -1,28 +1,120 @@
 package com.wolt.blurhashapp
 
+import android.graphics.Bitmap
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.os.SystemClock
-import android.view.View
-import android.widget.EditText
-import android.widget.ImageView
+import android.view.View.INVISIBLE
+import android.view.View.VISIBLE
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.*
 import com.wolt.blurhashkt.BlurHashDecoder
 import kotlinx.android.synthetic.main.activity_main.*
+import java.util.concurrent.Executors
+import kotlin.math.pow
 
 class MainActivity : AppCompatActivity() {
+
+    private lateinit var vm: Vm
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        val etInput: EditText = findViewById(R.id.etInput)
-        val ivResult: ImageView = findViewById(R.id.ivResult)
-        findViewById<View>(R.id.tvDecode).setOnClickListener {
-            val start = SystemClock.elapsedRealtime()
+        vm = ViewModelProvider(this).get(Vm::class.java)
+        vm.observe(this, Observer {
+            when (it) {
+                "START" -> progressBar.visibility = VISIBLE
+                "END" -> progressBar.visibility = INVISIBLE
+                else -> {
+                    ivResultBenchmark.append("\n$it")
+                    ivResultBenchmark.scrollTo(0, ivResultBenchmark.layout.lineCount)
+                }
+            }
+        })
+        tvDecode.setOnClickListener {
             val bitmap = BlurHashDecoder.decode(etInput.text.toString(), 20, 12)
-            val time = SystemClock.elapsedRealtime() - start
             ivResult.setImageBitmap(bitmap)
-            ivResultMs.text = "Decode time: $time ms"
+            ivResultBenchmark.setText("")
+            vm.startBenchMark(etInput.text.toString())
         }
     }
 
+}
+
+/**
+ * Executes a function and return the time spent in milliseconds.
+ */
+private inline fun timed(function: () -> Unit): Long {
+    val start = SystemClock.elapsedRealtime()
+    function()
+    return SystemClock.elapsedRealtime() - start
+}
+
+class Vm : ViewModel() {
+    private val liveData = MutableLiveData<String>()
+    private val executor = Executors.newSingleThreadExecutor()
+    private val handler = Handler(Looper.getMainLooper())
+
+    fun observe(owner: LifecycleOwner, observer: Observer<in String>) {
+        liveData.observe(owner, observer)
+    }
+
+    fun startBenchMark(blurHash: String) {
+        executor.execute {
+            notifyBenchmark("START")
+        }
+        for (useArray in 1 downTo 0) {
+            val useArray1 = useArray == 1
+            for (useCache in 1 downTo 0) {
+                val useCache1 = useCache == 1
+                executor.execute {
+                    notifyBenchmark("-----------------------------------")
+                    notifyBenchmark("Array: $useArray1, cache: $useCache1")
+                    notifyBenchmark("-----------------------------------")
+                }
+                for (s in 1..3) {
+                    val width = 20 * 2.toDouble().pow(s - 1).toInt()
+                    val height = 12 * 2.toDouble().pow(s - 1).toInt()
+                    executor.execute {
+                        notifyBenchmark("width: $width, height: $height")
+                    }
+                    for (n in 1..3) {
+                        executor.execute {
+                            benchmark(10.toDouble().pow(n).toInt(), width, height, blurHash, useArray1, useCache1)
+                        }
+                    }
+                    executor.execute {
+                        notifyBenchmark("\n")
+                    }
+                }
+                val s = "-----------------------------------\n"
+                executor.execute {
+                    notifyBenchmark(s)
+                }
+            }
+        }
+        executor.execute {
+            notifyBenchmark("END")
+        }
+    }
+
+    private fun benchmark(max: Int, width: Int, height: Int, blurHash: String, useArray: Boolean, useCache: Boolean) {
+        notifyBenchmark("-> $max bitmaps")
+        var bmp: Bitmap? = null
+        val time = timed {
+            for (i in 1..max) {
+                bmp = BlurHashDecoder.decode(blurHash, width, height, useArray = useArray, useCache = useCache)
+            }
+        }
+        notifyBenchmark("<- $time ms, Avg: ${time / max.toDouble()} ms")
+        // log the bitmap size
+        println("bmp size: ${bmp?.byteCount}")
+    }
+
+    private fun notifyBenchmark(s: String) {
+        handler.post {
+            liveData.value = s
+        }
+    }
 }

--- a/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
+++ b/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
@@ -1,10 +1,7 @@
 package com.wolt.blurhashapp
 
 import android.graphics.Bitmap
-import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
-import android.os.SystemClock
+import android.os.*
 import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
 import androidx.appcompat.app.AppCompatActivity
@@ -64,6 +61,11 @@ class Vm : ViewModel() {
         executor.execute {
             notifyBenchmark("START")
         }
+        executor.execute {
+            notifyBenchmark("-----------------------------------")
+            notifyBenchmark("Device: ${Build.MANUFACTURER} - ${Build.MODEL}")
+            notifyBenchmark("OS: Android ${Build.VERSION.CODENAME} - API ${Build.VERSION.SDK_INT}")
+        }
         for (useArray in 1 downTo 0) {
             val useArray1 = useArray == 1
             for (useCache in 1 downTo 0) {
@@ -74,8 +76,8 @@ class Vm : ViewModel() {
                     notifyBenchmark("-----------------------------------")
                 }
                 for (s in 1..3) {
-                    val width = 20 * 2.toDouble().pow(s - 1).toInt()
-                    val height = 12 * 2.toDouble().pow(s - 1).toInt()
+                    val width = 20 * 2.0.pow(s - 1).toInt()
+                    val height = 12 * 2.0.pow(s - 1).toInt()
                     executor.execute {
                         notifyBenchmark("width: $width, height: $height")
                     }
@@ -102,6 +104,7 @@ class Vm : ViewModel() {
     private fun benchmark(max: Int, width: Int, height: Int, blurHash: String, useArray: Boolean, useCache: Boolean) {
         notifyBenchmark("-> $max bitmaps")
         var bmp: Bitmap? = null
+        BlurHashDecoder.clearCache()
         val time = timed {
             for (i in 1..max) {
                 bmp = BlurHashDecoder.decode(blurHash, width, height, useArray = useArray, useCache = useCache)

--- a/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
+++ b/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
@@ -69,22 +69,22 @@ class Vm : ViewModel() {
         executor.execute {
             notifyBenchmark("-----------------------------------")
         }
-        for (tasks in 1..6) {
+        for (tasks in 1..3) {
             executor.execute {
                 notifyBenchmark("")
                 notifyBenchmark("-----------------------------------")
                 notifyBenchmark("Parallel tasks: $tasks")
                 notifyBenchmark("-----------------------------------")
             }
-            for (size in 1..1) {
+            for (size in 1..3) {
                 val width = 20 * 2.0.pow(size - 1).toInt()
                 val height = 12 * 2.0.pow(size - 1).toInt()
                 executor.execute {
                     notifyBenchmark("width: $width, height: $height")
                 }
-                for (n in 0..3) {
+                for (imageCount in 0..2) {
                     executor.execute {
-                        benchmark(10.0.pow(n).toInt(), width, height, blurHash, useCache = true, tasks = tasks)
+                        benchmark(10.0.pow(imageCount).toInt(), width, height, blurHash, useCache = true, tasks = tasks)
                     }
                 }
                 executor.execute {
@@ -105,12 +105,13 @@ class Vm : ViewModel() {
         notifyBenchmark("-> $max bitmaps")
         var bmp: Bitmap? = null
         BlurHashDecoder.clearCache()
-        val time = timed {
-            for (i in 1..max) {
+        val listOfTimes = ArrayList<Long>()
+        for (i in 1..max) {
+            listOfTimes.add(timed {
                 bmp = BlurHashDecoder.decode(blurHash, width, height, useCache = useCache, parallelTasks = tasks)
-            }
+            })
         }
-        notifyBenchmark("<- $time ms, Avg: ${time / max.toDouble()} ms")
+        notifyBenchmark("<- ${listOfTimes.sum()} ms, Avg: ${listOfTimes.sum() / max.toDouble()} ms, Max: ${listOfTimes.max()}, Min: ${listOfTimes.min()}")
         // log the bitmap size
         println("bmp size: ${bmp?.byteCount}")
     }

--- a/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
+++ b/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
@@ -69,19 +69,27 @@ class Vm : ViewModel() {
         executor.execute {
             notifyBenchmark("-----------------------------------")
         }
-        for (s in 1..3) {
-            val width = 20 * 2.0.pow(s - 1).toInt()
-            val height = 12 * 2.0.pow(s - 1).toInt()
+        for (tasks in 1..3) {
             executor.execute {
-                notifyBenchmark("width: $width, height: $height")
+                notifyBenchmark("")
+                notifyBenchmark("-----------------------------------")
+                notifyBenchmark("Parallel tasks: $tasks")
+                notifyBenchmark("-----------------------------------")
             }
-            for (n in 0..3) {
+            for (size in 1..3) {
+                val width = 20 * 2.0.pow(size - 1).toInt()
+                val height = 12 * 2.0.pow(size - 1).toInt()
                 executor.execute {
-                    benchmark(10.0.pow(n).toInt(), width, height, blurHash)
+                    notifyBenchmark("width: $width, height: $height")
                 }
-            }
-            executor.execute {
-                notifyBenchmark("\n")
+                for (n in 0..3) {
+                    executor.execute {
+                        benchmark(10.0.pow(n).toInt(), width, height, blurHash, useCache = true, tasks = tasks)
+                    }
+                }
+                executor.execute {
+                    notifyBenchmark("\n")
+                }
             }
         }
         val s = "-----------------------------------\n"
@@ -93,13 +101,13 @@ class Vm : ViewModel() {
         }
     }
 
-    private fun benchmark(max: Int, width: Int, height: Int, blurHash: String, useCache: Boolean = true) {
+    private fun benchmark(max: Int, width: Int, height: Int, blurHash: String, useCache: Boolean, tasks: Int) {
         notifyBenchmark("-> $max bitmaps")
         var bmp: Bitmap? = null
         BlurHashDecoder.clearCache()
         val time = timed {
             for (i in 1..max) {
-                bmp = BlurHashDecoder.decode(blurHash, width, height, useCache = useCache)
+                bmp = BlurHashDecoder.decode(blurHash, width, height, useCache = useCache, parallelTasks = tasks)
             }
         }
         notifyBenchmark("<- $time ms, Avg: ${time / max.toDouble()} ms")

--- a/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
+++ b/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
@@ -66,48 +66,40 @@ class Vm : ViewModel() {
             notifyBenchmark("Device: ${Build.MANUFACTURER} - ${Build.MODEL}")
             notifyBenchmark("OS: Android ${Build.VERSION.CODENAME} - API ${Build.VERSION.SDK_INT}")
         }
-        for (useArray in 1 downTo 0) {
-            val useArray1 = useArray == 1
-            for (useCache in 1 downTo 0) {
-                val useCache1 = useCache == 1
+        executor.execute {
+            notifyBenchmark("-----------------------------------")
+        }
+        for (s in 1..3) {
+            val width = 20 * 2.0.pow(s - 1).toInt()
+            val height = 12 * 2.0.pow(s - 1).toInt()
+            executor.execute {
+                notifyBenchmark("width: $width, height: $height")
+            }
+            for (n in 0..3) {
                 executor.execute {
-                    notifyBenchmark("-----------------------------------")
-                    notifyBenchmark("Array: $useArray1, cache: $useCache1")
-                    notifyBenchmark("-----------------------------------")
-                }
-                for (s in 1..3) {
-                    val width = 20 * 2.0.pow(s - 1).toInt()
-                    val height = 12 * 2.0.pow(s - 1).toInt()
-                    executor.execute {
-                        notifyBenchmark("width: $width, height: $height")
-                    }
-                    for (n in 1..3) {
-                        executor.execute {
-                            benchmark(10.toDouble().pow(n).toInt(), width, height, blurHash, useArray1, useCache1)
-                        }
-                    }
-                    executor.execute {
-                        notifyBenchmark("\n")
-                    }
-                }
-                val s = "-----------------------------------\n"
-                executor.execute {
-                    notifyBenchmark(s)
+                    benchmark(10.0.pow(n).toInt(), width, height, blurHash)
                 }
             }
+            executor.execute {
+                notifyBenchmark("\n")
+            }
+        }
+        val s = "-----------------------------------\n"
+        executor.execute {
+            notifyBenchmark(s)
         }
         executor.execute {
             notifyBenchmark("END")
         }
     }
 
-    private fun benchmark(max: Int, width: Int, height: Int, blurHash: String, useArray: Boolean, useCache: Boolean) {
+    private fun benchmark(max: Int, width: Int, height: Int, blurHash: String, useCache: Boolean = true) {
         notifyBenchmark("-> $max bitmaps")
         var bmp: Bitmap? = null
         BlurHashDecoder.clearCache()
         val time = timed {
             for (i in 1..max) {
-                bmp = BlurHashDecoder.decode(blurHash, width, height, useArray = useArray, useCache = useCache)
+                bmp = BlurHashDecoder.decode(blurHash, width, height, useCache = useCache)
             }
         }
         notifyBenchmark("<- $time ms, Avg: ${time / max.toDouble()} ms")

--- a/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
+++ b/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
@@ -48,6 +48,8 @@ private inline fun timed(function: () -> Unit): Long {
     return SystemClock.elapsedRealtimeNanos() - start
 }
 
+private const val NANOS = 1000000.0
+
 class Vm : ViewModel() {
     private val liveData = MutableLiveData<String>()
     private val executor = Executors.newSingleThreadExecutor()
@@ -111,7 +113,10 @@ class Vm : ViewModel() {
                 bmp = BlurHashDecoder.decode(blurHash, width, height, useCache = useCache, parallelTasks = tasks)
             })
         }
-        notifyBenchmark("<- ${listOfTimes.sum() / 1000000.0} ms, Avg: ${listOfTimes.sum() / 1000000.0 / max.toDouble()} ms, Max: ${(listOfTimes.max()?.toDouble() ?: 0.0) / 1000000.0}, Min: ${(listOfTimes.min()?.toDouble() ?: 0.0) / 1000000.0}")
+        notifyBenchmark("<- ${listOfTimes.sum().millis().format()} ms, " +
+                "Avg: ${(listOfTimes.sum().millis() / max.toDouble()).format()} ms, " +
+                "Max: ${listOfTimes.max().millis().format()}, " +
+                "Min: ${listOfTimes.min().millis().format()}")
         // log the bitmap size
         println("bmp size: ${bmp?.byteCount}")
     }
@@ -122,3 +127,6 @@ class Vm : ViewModel() {
         }
     }
 }
+
+private fun Long?.millis() = (this?.toDouble() ?: 0.0) / NANOS
+private fun Double.format() = "%.${2}f".format(this)

--- a/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
+++ b/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
@@ -43,9 +43,9 @@ class MainActivity : AppCompatActivity() {
  * Executes a function and return the time spent in milliseconds.
  */
 private inline fun timed(function: () -> Unit): Long {
-    val start = SystemClock.elapsedRealtime()
+    val start = SystemClock.elapsedRealtimeNanos()
     function()
-    return SystemClock.elapsedRealtime() - start
+    return SystemClock.elapsedRealtimeNanos() - start
 }
 
 class Vm : ViewModel() {
@@ -111,7 +111,7 @@ class Vm : ViewModel() {
                 bmp = BlurHashDecoder.decode(blurHash, width, height, useCache = useCache, parallelTasks = tasks)
             })
         }
-        notifyBenchmark("<- ${listOfTimes.sum()} ms, Avg: ${listOfTimes.sum() / max.toDouble()} ms, Max: ${listOfTimes.max()}, Min: ${listOfTimes.min()}")
+        notifyBenchmark("<- ${listOfTimes.sum() / 1000000.0} ms, Avg: ${listOfTimes.sum() / 1000000.0 / max.toDouble()} ms, Max: ${(listOfTimes.max()?.toDouble() ?: 0.0) / 1000000.0}, Min: ${(listOfTimes.min()?.toDouble() ?: 0.0) / 1000000.0}")
         // log the bitmap size
         println("bmp size: ${bmp?.byteCount}")
     }

--- a/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
+++ b/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
@@ -69,14 +69,14 @@ class Vm : ViewModel() {
         executor.execute {
             notifyBenchmark("-----------------------------------")
         }
-        for (tasks in 1..3) {
+        for (tasks in 1..6) {
             executor.execute {
                 notifyBenchmark("")
                 notifyBenchmark("-----------------------------------")
                 notifyBenchmark("Parallel tasks: $tasks")
                 notifyBenchmark("-----------------------------------")
             }
-            for (size in 1..3) {
+            for (size in 1..1) {
                 val width = 20 * 2.0.pow(size - 1).toInt()
                 val height = 12 * 2.0.pow(size - 1).toInt()
                 executor.execute {

--- a/Kotlin/demo/src/main/res/layout/activity_main.xml
+++ b/Kotlin/demo/src/main/res/layout/activity_main.xml
@@ -41,12 +41,26 @@
         android:layout_marginTop="24dp"
         android:adjustViewBounds="true" />
 
-    <TextView
-        android:id="@+id/ivResultMs"
-        android:layout_width="wrap_content"
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:layout_gravity="center"
+        android:layout_margin="4dp"
+        android:visibility="invisible"
+        tools:visibility="visible" />
+
+    <EditText
+        android:id="@+id/ivResultBenchmark"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:layout_marginTop="8dp"
+        android:editable="false"
+        android:inputType="none"
+        android:scrollbars="vertical"
+        android:textIsSelectable="true"
+        android:textSize="16sp"
         tools:text="0 ms" />
+
 
 </LinearLayout>

--- a/Kotlin/demo/src/main/res/layout/activity_main.xml
+++ b/Kotlin/demo/src/main/res/layout/activity_main.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
@@ -39,5 +40,13 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="24dp"
         android:adjustViewBounds="true" />
+
+    <TextView
+        android:id="@+id/ivResultMs"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginTop="8dp"
+        tools:text="0 ms" />
 
 </LinearLayout>

--- a/Kotlin/lib/build.gradle
+++ b/Kotlin/lib/build.gradle
@@ -27,4 +27,9 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.7'
+
+    androidTestImplementation 'junit:junit:4.13'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
 }

--- a/Kotlin/lib/src/main/java/com/wolt/blurhashkt/BlurHashDecoder.kt
+++ b/Kotlin/lib/src/main/java/com/wolt/blurhashkt/BlurHashDecoder.kt
@@ -91,13 +91,7 @@ object BlurHashDecoder {
         val calculateCosX = !USE_CACHE_FOR_MATH_COS || !cacheCosinesX.containsKey(width * numCompX)
         val cosinesX: DoubleArray = getCosinesX(calculateCosX, width, numCompX)
         val calculateCosY = !USE_CACHE_FOR_MATH_COS || !cacheCosinesY.containsKey(height * numCompY)
-        val cosinesY: DoubleArray
-        if (calculateCosY) {
-            cosinesY = DoubleArray(height * numCompY)
-            cacheCosinesY[height * numCompY] = cosinesY
-        } else {
-            cosinesY = cacheCosinesY[height * numCompY]!!
-        }
+        val cosinesY: DoubleArray = getCosinesY(calculateCosY, height, numCompY)
         for (y in 0 until height) {
             for (x in 0 until width) {
                 var r = 0f
@@ -118,6 +112,17 @@ object BlurHashDecoder {
             }
         }
         return Bitmap.createBitmap(imageArray, width, height, Bitmap.Config.ARGB_8888)
+    }
+
+    private fun getCosinesY(calculateCosY: Boolean, height: Int, numCompY: Int): DoubleArray {
+        val cosinesY: DoubleArray
+        if (calculateCosY) {
+            cosinesY = DoubleArray(height * numCompY)
+            cacheCosinesY[height * numCompY] = cosinesY
+        } else {
+            cosinesY = cacheCosinesY[height * numCompY]!!
+        }
+        return cosinesY
     }
 
     private fun getCosY(

--- a/Kotlin/lib/src/main/java/com/wolt/blurhashkt/BlurHashDecoder.kt
+++ b/Kotlin/lib/src/main/java/com/wolt/blurhashkt/BlurHashDecoder.kt
@@ -2,22 +2,17 @@ package com.wolt.blurhashkt
 
 import android.graphics.Bitmap
 import android.graphics.Color
-import java.util.*
 import kotlin.math.cos
 import kotlin.math.pow
 import kotlin.math.withSign
-
-// this is to optimize the number of calculations for "Math.cos()",
-// is is slow and for many images with same size it can be cached, improving performance.
-// the improvement can be noticed with images bigger than 80x80
-private const val USE_CACHE_FOR_MATH_COS = true
 
 object BlurHashDecoder {
 
     private val cacheCosinesX = HashMap<Int, DoubleArray>()
     private val cacheCosinesY = HashMap<Int, DoubleArray>()
 
-    fun decode(blurHash: String?, width: Int, height: Int, punch: Float = 1f): Bitmap? {
+    fun decode(blurHash: String?, width: Int, height: Int, punch: Float = 1f, useArray: Boolean = true, useCache: Boolean = true): Bitmap? {
+
         if (blurHash == null || blurHash.length < 6) {
             return null
         }
@@ -39,7 +34,10 @@ object BlurHashDecoder {
                 decodeAc(colorEnc, maxAc * punch)
             }
         }
-        return composeBitmap(width, height, numCompX, numCompY, colors)
+        if (useArray)
+            return composeBitmapArray(width, height, numCompX, numCompY, colors, useCache)
+        else
+            return composeBitmap(width, height, numCompX, numCompY, colors, useCache)
     }
 
     private fun decode83(str: String, from: Int = 0, to: Int = str.length): Int {
@@ -82,16 +80,17 @@ object BlurHashDecoder {
 
     private fun signedPow2(value: Float) = value.pow(2f).withSign(value)
 
-    private fun composeBitmap(
+    private fun composeBitmapArray(
             width: Int, height: Int,
             numCompX: Int, numCompY: Int,
-            colors: Array<FloatArray>
+            colors: Array<FloatArray>,
+            useCache: Boolean
     ): Bitmap {
         // use an array for better performance when writing pixel colors
         val imageArray = IntArray(width * height)
-        val calculateCosX = !USE_CACHE_FOR_MATH_COS || !cacheCosinesX.containsKey(width * numCompX)
+        val calculateCosX = !useCache || !cacheCosinesX.containsKey(width * numCompX)
         val cosinesX = getCosinesX(calculateCosX, width, numCompX)
-        val calculateCosY = !USE_CACHE_FOR_MATH_COS || !cacheCosinesY.containsKey(height * numCompY)
+        val calculateCosY = !useCache || !cacheCosinesY.containsKey(height * numCompY)
         val cosinesY = getCosinesY(calculateCosY, height, numCompY)
         for (y in 0 until height) {
             for (x in 0 until width) {
@@ -113,6 +112,39 @@ object BlurHashDecoder {
             }
         }
         return Bitmap.createBitmap(imageArray, width, height, Bitmap.Config.ARGB_8888)
+    }
+
+    private fun composeBitmap(
+            width: Int, height: Int,
+            numCompX: Int, numCompY: Int,
+            colors: Array<FloatArray>,
+            useCache: Boolean
+    ): Bitmap {
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        val calculateCosX = !useCache || !cacheCosinesX.containsKey(width * numCompX)
+        val cosinesX = getCosinesX(calculateCosX, width, numCompX)
+        val calculateCosY = !useCache || !cacheCosinesY.containsKey(height * numCompY)
+        val cosinesY = getCosinesY(calculateCosY, height, numCompY)
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                var r = 0f
+                var g = 0f
+                var b = 0f
+                for (j in 0 until numCompY) {
+                    for (i in 0 until numCompX) {
+                        val cosX = getCosX(calculateCosX, cosinesX, i, numCompX, x, width)
+                        val cosY = getCosY(calculateCosY, cosinesY, j, numCompY, y, height)
+                        val basis = (cosX * cosY).toFloat()
+                        val color = colors[j * numCompX + i]
+                        r += color[0] * basis
+                        g += color[1] * basis
+                        b += color[2] * basis
+                    }
+                }
+                bitmap.setPixel(x, y, Color.rgb(linearToSrgb(r), linearToSrgb(g), linearToSrgb(b)))
+            }
+        }
+        return bitmap
     }
 
     private fun getCosinesY(calculateCosY: Boolean, height: Int, numCompY: Int): DoubleArray {

--- a/Kotlin/lib/src/main/java/com/wolt/blurhashkt/BlurHashDecoder.kt
+++ b/Kotlin/lib/src/main/java/com/wolt/blurhashkt/BlurHashDecoder.kt
@@ -89,9 +89,9 @@ object BlurHashDecoder {
         // use an array for better performance when writing pixel colors
         val imageArray = IntArray(width * height)
         val calculateCosX = !USE_CACHE_FOR_MATH_COS || !cacheCosinesX.containsKey(width * numCompX)
-        val cosinesX: DoubleArray = getCosinesX(calculateCosX, width, numCompX)
+        val cosinesX = getCosinesX(calculateCosX, width, numCompX)
         val calculateCosY = !USE_CACHE_FOR_MATH_COS || !cacheCosinesY.containsKey(height * numCompY)
-        val cosinesY: DoubleArray = getCosinesY(calculateCosY, height, numCompY)
+        val cosinesY = getCosinesY(calculateCosY, height, numCompY)
         for (y in 0 until height) {
             for (x in 0 until width) {
                 var r = 0f
@@ -134,11 +134,9 @@ object BlurHashDecoder {
             height: Int
     ): Double {
         if (calculateCosY) {
-            cosinesY[j + numCompY * y] =
-                    cos(Math.PI * y * j / height)
+            cosinesY[j + numCompY * y] = cos(Math.PI * y * j / height)
         }
-        val cosY = cosinesY[j + numCompY * y]
-        return cosY
+        return cosinesY[j + numCompY * y]
     }
 
     private fun getCosX(
@@ -150,11 +148,9 @@ object BlurHashDecoder {
             width: Int
     ): Double {
         if (calculateCosX) {
-            cosinesX[i + numCompX * x] =
-                    cos(Math.PI * x * i / width)
+            cosinesX[i + numCompX * x] = cos(Math.PI * x * i / width)
         }
-        val cosX = cosinesX[i + numCompX * x]
-        return cosX
+        return cosinesX[i + numCompX * x]
     }
 
     private fun getCosinesX(calculateCosX: Boolean, width: Int, numCompX: Int): DoubleArray {
@@ -177,14 +173,13 @@ object BlurHashDecoder {
         }
     }
 
-    val listOfChars = listOf(
+    private val charMap = listOf(
             '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G',
             'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
             'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o',
             'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '#', '$', '%', '*', '+', ',',
             '-', '.', ':', ';', '=', '?', '@', '[', ']', '^', '_', '{', '|', '}', '~'
     )
-    private val charMap = listOfChars
             .mapIndexed { i, c -> c to i }
             .toMap()
 

--- a/Kotlin/lib/src/main/java/com/wolt/blurhashkt/BlurHashDecoder.kt
+++ b/Kotlin/lib/src/main/java/com/wolt/blurhashkt/BlurHashDecoder.kt
@@ -11,6 +11,11 @@ object BlurHashDecoder {
     private val cacheCosinesX = HashMap<Int, DoubleArray>()
     private val cacheCosinesY = HashMap<Int, DoubleArray>()
 
+    fun clearCache() {
+        cacheCosinesX.clear()
+        cacheCosinesY.clear()
+    }
+
     fun decode(blurHash: String?, width: Int, height: Int, punch: Float = 1f, useArray: Boolean = true, useCache: Boolean = true): Bitmap? {
 
         if (blurHash == null || blurHash.length < 6) {

--- a/Kotlin/lib/src/main/java/com/wolt/blurhashkt/BlurHashDecoder.kt
+++ b/Kotlin/lib/src/main/java/com/wolt/blurhashkt/BlurHashDecoder.kt
@@ -9,6 +9,7 @@ import kotlin.math.withSign
 
 // this is to optimize the number of calculations for "Math.cos()",
 // is is slow and for many images with same size it can be cached, improving performance.
+// the improvement can be noticed with images bigger than 80x80
 private const val USE_CACHE_FOR_MATH_COS = true
 
 object BlurHashDecoder {

--- a/Kotlin/lib/src/main/java/com/wolt/blurhashkt/BlurHashDecoder.kt
+++ b/Kotlin/lib/src/main/java/com/wolt/blurhashkt/BlurHashDecoder.kt
@@ -42,7 +42,10 @@ object BlurHashDecoder {
                 decodeAc(colorEnc, maxAc * punch)
             }
         }
-        return composeBitmap(width, height, numCompX, numCompY, colors, useCache, parallelTasks)
+        return when (parallelTasks) {
+            1 -> composeBitmap(width, height, numCompX, numCompY, colors, useCache)
+            else -> composeBitmapCoroutines(width, height, numCompX, numCompY, colors, useCache, parallelTasks)
+        }
     }
 
     private fun decode83(str: String, from: Int = 0, to: Int = str.length): Int {
@@ -89,15 +92,49 @@ object BlurHashDecoder {
             width: Int, height: Int,
             numCompX: Int, numCompY: Int,
             colors: Array<FloatArray>,
+            useCache: Boolean
+    ): Bitmap {
+        // use an array for better performance when writing pixel colors
+        val imageArray = IntArray(width * height)
+        val calculateCosX = !useCache || !cacheCosinesX.containsKey(width * numCompX)
+        val cosinesX = getArrayForCosinesX(calculateCosX, width, numCompX)
+        val calculateCosY = !useCache || !cacheCosinesY.containsKey(height * numCompY)
+        val cosinesY = getArrayForCosinesY(calculateCosY, height, numCompY)
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                var r = 0f
+                var g = 0f
+                var b = 0f
+                for (j in 0 until numCompY) {
+                    for (i in 0 until numCompX) {
+                        val cosX = cosinesX.getCos(calculateCosX, i, numCompX, x, width)
+                        val cosY = cosinesY.getCos(calculateCosY, j, numCompY, y, height)
+                        val basis = (cosX * cosY).toFloat()
+                        val color = colors[j * numCompX + i]
+                        r += color[0] * basis
+                        g += color[1] * basis
+                        b += color[2] * basis
+                    }
+                }
+                imageArray[x + width * y] = Color.rgb(linearToSrgb(r), linearToSrgb(g), linearToSrgb(b))
+            }
+        }
+        return Bitmap.createBitmap(imageArray, width, height, Bitmap.Config.ARGB_8888)
+    }
+
+    private fun composeBitmapCoroutines(
+            width: Int, height: Int,
+            numCompX: Int, numCompY: Int,
+            colors: Array<FloatArray>,
             useCache: Boolean,
             parallelTasks: Int
     ): Bitmap {
         // use an array for better performance when writing pixel colors
         val imageArray = IntArray(width * height)
         val calculateCosX = !useCache || !cacheCosinesX.containsKey(width * numCompX)
-        val cosinesX = getCosinesX(calculateCosX, width, numCompX)
+        val cosinesX = getArrayForCosinesX(calculateCosX, width, numCompX)
         val calculateCosY = !useCache || !cacheCosinesY.containsKey(height * numCompY)
-        val cosinesY = getCosinesY(calculateCosY, height, numCompY)
+        val cosinesY = getArrayForCosinesY(calculateCosY, height, numCompY)
         runBlocking {
             COROUTINES_SCOPE_FOR_PARALLEL_TASKS.launch {
                 val tasks = ArrayList<Deferred<Unit>>()
@@ -136,8 +173,8 @@ object BlurHashDecoder {
             var b = 0f
             for (j in 0 until numCompY) {
                 for (i in 0 until numCompX) {
-                    val cosX = getCosX(calculateCosX, cosinesX, i, numCompX, x, width)
-                    val cosY = getCosY(calculateCosY, cosinesY, j, numCompY, y, height)
+                    val cosX = cosinesX.getCos(calculateCosX, i, numCompX, x, width)
+                    val cosY = cosinesY.getCos(calculateCosY, j, numCompY, y, height)
                     val basis = (cosX * cosY).toFloat()
                     val color = colors[j * numCompX + i]
                     r += color[0] * basis
@@ -149,54 +186,31 @@ object BlurHashDecoder {
         }
     }
 
-    private fun getCosinesY(calculateCosY: Boolean, height: Int, numCompY: Int): DoubleArray {
-        val cosinesY: DoubleArray
-        if (calculateCosY) {
-            cosinesY = DoubleArray(height * numCompY)
-            cacheCosinesY[height * numCompY] = cosinesY
-        } else {
-            cosinesY = cacheCosinesY[height * numCompY]!!
-        }
-        return cosinesY
-    }
-
-    private fun getCosY(
-            calculateCosY: Boolean,
-            cosinesY: DoubleArray,
-            j: Int,
-            numCompY: Int,
-            y: Int,
-            height: Int
-    ): Double {
-        if (calculateCosY) {
-            cosinesY[j + numCompY * y] = cos(Math.PI * y * j / height)
-        }
-        return cosinesY[j + numCompY * y]
-    }
-
-    private fun getCosX(
-            calculateCosX: Boolean,
-            cosinesX: DoubleArray,
-            i: Int,
-            numCompX: Int,
-            x: Int,
-            width: Int
-    ): Double {
-        if (calculateCosX) {
-            cosinesX[i + numCompX * x] = cos(Math.PI * x * i / width)
-        }
-        return cosinesX[i + numCompX * x]
-    }
-
-    private fun getCosinesX(calculateCosX: Boolean, width: Int, numCompX: Int): DoubleArray {
-        return when {
-            calculateCosX -> {
-                DoubleArray(width * numCompX).also {
-                    cacheCosinesX[width * numCompX] = it
-                }
+    private fun getArrayForCosinesY(calculate: Boolean, height: Int, numCompY: Int) = when {
+        calculate -> {
+            DoubleArray(height * numCompY).also {
+                cacheCosinesY[height * numCompY] = it
             }
-            else -> cacheCosinesX[width * numCompX]!!
         }
+        else -> {
+            cacheCosinesY[height * numCompY]!!
+        }
+    }
+
+    private fun getArrayForCosinesX(calculate: Boolean, width: Int, numCompX: Int) = when {
+        calculate -> {
+            DoubleArray(width * numCompX).also {
+                cacheCosinesX[width * numCompX] = it
+            }
+        }
+        else -> cacheCosinesX[width * numCompX]!!
+    }
+
+    private fun DoubleArray.getCos(calculate: Boolean, x: Int, numComp: Int, y: Int, size: Int): Double {
+        if (calculate) {
+            this[x + numComp * y] = cos(Math.PI * y * x / size)
+        }
+        return this[x + numComp * y]
     }
 
     private fun linearToSrgb(value: Float): Int {


### PR DESCRIPTION
Using coroutines to generate parts of the image in parallel shows a good performance **but only for images >= 48x24**, specially with 3 tasks.

Here the benchmark in my Galaxy A5. The performance increases 50% with 3 parallel tasks.

The result for 1 task is not using any coroutine.

To compare a benchmark result code without coroutines, you can use the branch https://github.com/ignaciotcrespo/blurhash/tree/benchmark-array-cacheEnabled

<details>
<summary>Galaxy A5, current version array + cache</summary>

```
-----------------------------------
Device: samsung - SM-A500FU
OS: Android REL - API 23
-----------------------------------
Array: true, cache: true
-----------------------------------
width: 20, height: 12
-> 10 bitmaps
<- 30 ms, Avg: 3.0 ms
-> 100 bitmaps
<- 186 ms, Avg: 1.86 ms


width: 40, height: 24
-> 10 bitmaps
<- 83 ms, Avg: 8.3 ms
-> 100 bitmaps
<- 731 ms, Avg: 7.31 ms


width: 80, height: 48
-> 10 bitmaps
<- 335 ms, Avg: 33.5 ms
-> 100 bitmaps
<- 2924 ms, Avg: 29.24 ms
```

</details>

<details>
<summary>Galaxy A5, using coroutines</summary>

```
-----------------------------------
Device: samsung - SM-A500FU
OS: Android REL - API 23
-----------------------------------

-----------------------------------
Parallel tasks: 1
-----------------------------------
width: 20, height: 12
-> 1 bitmaps
<- 5.00 ms, Avg: 5.00 ms, Max: 5.00, Min: 5.00
-> 10 bitmaps
<- 25.06 ms, Avg: 2.51 ms, Max: 7.14, Min: 1.81
-> 100 bitmaps
<- 196.96 ms, Avg: 1.97 ms, Max: 5.24, Min: 1.77


width: 40, height: 24
-> 1 bitmaps
<- 20.28 ms, Avg: 20.28 ms, Max: 20.28, Min: 20.28
-> 10 bitmaps
<- 85.42 ms, Avg: 8.54 ms, Max: 20.03, Min: 6.97
-> 100 bitmaps
<- 737.50 ms, Avg: 7.37 ms, Max: 20.15, Min: 6.86


width: 80, height: 48
-> 1 bitmaps
<- 79.84 ms, Avg: 79.84 ms, Max: 79.84, Min: 79.84
-> 10 bitmaps
<- 337.62 ms, Avg: 33.76 ms, Max: 81.32, Min: 28.03
-> 100 bitmaps
<- 2921.94 ms, Avg: 29.22 ms, Max: 79.32, Min: 28.01



-----------------------------------
Parallel tasks: 2
-----------------------------------
width: 20, height: 12
-> 1 bitmaps
<- 3.94 ms, Avg: 3.94 ms, Max: 3.94, Min: 3.94
-> 10 bitmaps
<- 26.48 ms, Avg: 2.65 ms, Max: 4.30, Min: 2.05
-> 100 bitmaps
<- 222.35 ms, Avg: 2.22 ms, Max: 5.54, Min: 1.62


width: 40, height: 24
-> 1 bitmaps
<- 12.43 ms, Avg: 12.43 ms, Max: 12.43, Min: 12.43
-> 10 bitmaps
<- 63.46 ms, Avg: 6.35 ms, Max: 15.74, Min: 4.81
-> 100 bitmaps
<- 566.36 ms, Avg: 5.66 ms, Max: 12.67, Min: 4.30


width: 80, height: 48
-> 1 bitmaps
<- 43.52 ms, Avg: 43.52 ms, Max: 43.52, Min: 43.52
-> 10 bitmaps
<- 192.24 ms, Avg: 19.22 ms, Max: 40.43, Min: 15.52
-> 100 bitmaps
<- 1725.76 ms, Avg: 17.26 ms, Max: 42.17, Min: 15.24



-----------------------------------
Parallel tasks: 3
-----------------------------------
width: 20, height: 12
-> 1 bitmaps
<- 5.10 ms, Avg: 5.10 ms, Max: 5.10, Min: 5.10
-> 10 bitmaps
<- 32.44 ms, Avg: 3.24 ms, Max: 6.40, Min: 1.94
-> 100 bitmaps
<- 241.19 ms, Avg: 2.41 ms, Max: 6.21, Min: 1.72


width: 40, height: 24
-> 1 bitmaps
<- 7.58 ms, Avg: 7.58 ms, Max: 7.58, Min: 7.58
-> 10 bitmaps
<- 47.92 ms, Avg: 4.79 ms, Max: 9.27, Min: 3.54
-> 100 bitmaps
<- 425.90 ms, Avg: 4.26 ms, Max: 7.73, Min: 3.14


width: 80, height: 48
-> 1 bitmaps
<- 38.00 ms, Avg: 38.00 ms, Max: 38.00, Min: 38.00
-> 10 bitmaps
<- 148.51 ms, Avg: 14.85 ms, Max: 36.44, Min: 11.12
-> 100 bitmaps
<- 1327.79 ms, Avg: 13.28 ms, Max: 30.85, Min: 10.78
```

</details>