### PR TITLE
Initial support for Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ Python/build/
 *.so
 *.o
 *.pyc
+.build/
 
 # Website
 Website/node_modules/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+// swift build -Xswiftc "-sdk" -Xswiftc "`xcrun --sdk iphonesimulator --show-sdk-path`" -Xswiftc "-target" -Xswiftc "x86_64-apple-ios13.0-simulator"
+
+import PackageDescription
+
+let package = Package(
+    name: "blurhash",
+    defaultLocalization: "en",
+    products: [
+        .library(
+            name: "BlurHash",
+            targets: ["BlurHash"]
+        ),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "BlurHash",
+            dependencies: [],
+            path: "./Swift",
+            exclude: [
+                "BlurHashKit",
+                "BlurHashTest",
+                "License.txt",
+                "Readme.md",
+            ],
+            sources: [
+                "BlurHashDecode.swift",
+                "BlurHashEncode.swift",
+            ]
+        ),
+    ]
+)

--- a/Swift/Readme.md
+++ b/Swift/Readme.md
@@ -6,6 +6,16 @@
 and encoder for BlurHash to and from `UIImage`. Both files are completeiy standalone, and can simply be copied into your
 project directly.
 
+### Usage
+
+#### Swift Package Manager
+
+Add the following dependency to your Package.swift file:
+
+```swift
+.package(name: "blurhash", url: "https://github.com/woltapp/blurhash.git", .branch("master")),
+```
+
 ### Decoding
 
 [BlurHashDecode.swift](BlurHashDecode.swift) implements the following extension on `UIImage`:


### PR DESCRIPTION
This PR allows folks to use this library as a Swift package in their iOS apps by declaring a simple dependency:

```swift
.package(name: "blurhash", url: "https://github.com/woltapp/blurhash.git", .branch("master"))
```
