### PR TITLE
Use SparseArrayCompat for better performance

### DIFF
--- a/Kotlin/lib/src/main/java/com/wolt/blurhashkt/BlurHashDecoder.kt
+++ b/Kotlin/lib/src/main/java/com/wolt/blurhashkt/BlurHashDecoder.kt
@@ -2,6 +2,7 @@ package com.wolt.blurhashkt
 
 import android.graphics.Bitmap
 import android.graphics.Color
+import androidx.collection.SparseArrayCompat
 import kotlin.math.cos
 import kotlin.math.pow
 import kotlin.math.withSign
@@ -11,8 +12,8 @@ object BlurHashDecoder {
     // cache Math.cos() calculations to improve performance.
     // The number of calculations can be huge for many bitmaps: width * height * numCompX * numCompY * 2 * nBitmaps
     // the cache is enabled by default, it is recommended to disable it only when just a few images are displayed
-    private val cacheCosinesX = HashMap<Int, DoubleArray>()
-    private val cacheCosinesY = HashMap<Int, DoubleArray>()
+    private val cacheCosinesX = SparseArrayCompat<DoubleArray>()
+    private val cacheCosinesY = SparseArrayCompat<DoubleArray>()
 
     /**
      * Clear calculations stored in memory cache.
@@ -133,21 +134,21 @@ object BlurHashDecoder {
     private fun getArrayForCosinesY(calculate: Boolean, height: Int, numCompY: Int) = when {
         calculate -> {
             DoubleArray(height * numCompY).also {
-                cacheCosinesY[height * numCompY] = it
+                cacheCosinesY.put(height * numCompY, it)
             }
         }
         else -> {
-            cacheCosinesY[height * numCompY]!!
+            cacheCosinesY.get(height * numCompY)!!
         }
     }
 
     private fun getArrayForCosinesX(calculate: Boolean, width: Int, numCompX: Int) = when {
         calculate -> {
             DoubleArray(width * numCompX).also {
-                cacheCosinesX[width * numCompX] = it
+                cacheCosinesX.plut(width * numCompX, it)
             }
         }
-        else -> cacheCosinesX[width * numCompX]!!
+        else -> cacheCosinesX.get(width * numCompX)!!
     }
 
     private fun DoubleArray.getCos(


### PR DESCRIPTION
SparseArray can be used to replace HashMap when the key is a primitive type. There are some variants for different key/value types, even though not all of them are publicly available. let's take a look at the comparison:

`SparseIntArray`:
```java
class SparseIntArray {
    int[] keys;
    int[] values;
    int size;
}
```
```
Class = 12 + 3 * 4 = 24 bytes
Array = 20 + 1000 * 4 = 4024 bytes
Total = 8,072 bytes
```

`HashMap`:
```java
class HashMap<K, V> {
    Entry<K, V>[] table;
    Entry<K, V> forNull;
    int size;
    int modCount;
    int threshold;
    Set<K> keys
    Set<Entry<K, V>> entries;
    Collection<V> values;
}
```
```
Class = 12 + 8 * 4 = 48 bytes
Entry = 32 + 16 + 16 = 64 bytes
Array = 20 + 1000 * 64 = 64024 bytes
Total = 64,136 bytes
```

read more: https://speakerdeck.com/romainguy/android-memories?slide=90