### PR TITLE
add fast-blurhash reference

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,6 +55,7 @@ These cover our use cases, but could probably use polishing, extending and impro
 * [Elm](https://github.com/WhileTruu/elm-blurhash) - Encoder and decoder in Elm.
 * [Dart](https://github.com/justacid/blurhash-dart) - Encoder and decoder implementation in pure Dart.
 * [.NET](https://github.com/MarkusPalcer/blurhash.net) - Encoder and decoder in C#.
+* [JavaScript](https://github.com/mad-gooze/fast-blurhash) - Tiny optimized decoder implementation JS.
 
 Perhaps you'd like to help extend this list? Which brings us to...
 


### PR DESCRIPTION
Hi!

I created a smaller and faster decoder implementation in JS and I'd like to share a link to it.