### PR TITLE
Corrects formatting in /C/Readme.md

### DIFF
--- a/C/Readme.md
+++ b/C/Readme.md
@@ -34,5 +34,6 @@ Nevertheless, if you want to try it out quickly, simply run:
 	LaJHjmVu8_~po#smR+a~xaoLWCRj
 
 If you want to try out the decoder, simply run:
+
 	$ make blurhash_decoder
 	$ ./blurhash_decoder "LaJHjmVu8_~po#smR+a~xaoLWCRj" 32 32 decoded_output.png


### PR DESCRIPTION
CLI Decoder usage was not rendering as a code block, and there were unescaped strikethrough

Before:
![image](https://user-images.githubusercontent.com/8635304/118535640-f0f25700-b707-11eb-9251-df4319af535b.png)

After:
![image](https://user-images.githubusercontent.com/8635304/118535652-f5b70b00-b707-11eb-9d7c-a1a943f4c13f.png)
