### PR TITLE
Add meta tags for open graph protocol and twitter cards

### DIFF
--- a/Website/src/index.ejs
+++ b/Website/src/index.ejs
@@ -7,6 +7,15 @@
       content="width=device-width, initial-scale=1.0, minimum-scale=1, maximum-scale=1, user-scalable=0, shrink-to-fit=no"
     />
     <title><%= htmlWebpackPlugin.options.title %></title>
+    <meta property="og:title" content="BlurHash">
+    <meta property="og:description" content="BlurHash is a compact representation of a placeholder for an image.">
+    <meta property="og:image" content="https://blurha.sh/<%=require('../../Media/WhyBlurhash.png')%>">
+    <meta property="og:url" content="https://blurha.sh">
+    <meta property="og:type" content="website">
+    <meta name="twitter:title" content="BlurHash is a compact representation of a placeholder for an image.">
+    <meta name="twitter:image" content="https://blurha.sh/<%=require('../../Media/WhyBlurhash.png')%>">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta dname="twitter:site" content="@woltapp">
   </head>
   <body id="fullpage">
     <div class="hero section">


### PR DESCRIPTION
Lets https://blurha.sh more share friendly, adding meta tags.

Fixes #5.