### PR TITLE
Fix DC decoding

### DIFF
--- a/TypeScript/src/utils.ts
+++ b/TypeScript/src/utils.ts
@@ -10,9 +10,9 @@ export const sRGBToLinear = (value: number) => {
 export const linearTosRGB = (value: number) => {
   let v = Math.max(0, Math.min(1, value));
   if (v <= 0.0031308) {
-    return Math.round(v * 12.92 * 255 + 0.5);
+    return Math.trunc(v * 12.92 * 255 + 0.5);
   } else {
-    return Math.round((1.055 * Math.pow(v, 1 / 2.4) - 0.055) * 255 + 0.5);
+    return Math.trunc((1.055 * Math.pow(v, 1 / 2.4) - 0.055) * 255 + 0.5);
   }
 };
 


### PR DESCRIPTION
This PR fixes decode of the DC component by truncating instead of round the value.

## Before
![image](https://user-images.githubusercontent.com/10807938/178996787-72375761-62cb-40e5-9d81-ffa154e24308.png)

## After
![image](https://user-images.githubusercontent.com/10807938/178996526-178b4701-7a15-4c97-a7d3-63724a4fb978.png)


Fixes #13.