### PR TITLE
Add note about stimulus-blurhash

### DIFF
--- a/TypeScript/README.md
+++ b/TypeScript/README.md
@@ -11,7 +11,7 @@
 npm install --save blurhash
 ```
 
-See [react-blurhash](https://github.com/woltapp/react-blurhash) to use blurhash with React.
+See [react-blurhash](https://github.com/woltapp/react-blurhash) to use blurhash with React or [stimulus-blurhash](https://github.com/bb/stimulus-blurhash) to use it with Hotwire Stimulus.
 
 ## API
 


### PR DESCRIPTION
I admit it's self-promo, but still useful.

Also, compared to the react-version it uses background-image with data URL instead of adding a canvas element to the DOM.