### PR TITLE
fix: move default condition to last one

### DIFF
--- a/TypeScript/package.json
+++ b/TypeScript/package.json
@@ -9,11 +9,11 @@
     "./package.json": "./package.json",
     ".": {
       "browser": "./dist/esm/index.js",
-      "default": "./dist/index.js",
       "import": "./dist/index.mjs",
       "module": "./dist/esm/index.js",
       "node": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
   "sideEffects": false,


### PR DESCRIPTION
Got `Module not found: Error: Default condition should be last one` with 
`blurhash@2.0.2`

ref: https://nodejs.org/api/packages.html#conditional-exports

> "default" - the generic fallback that always matches. Can be a CommonJS or ES module file. This condition should always come last.