### PR TITLE
(TypeScript) Improve decode speed by avoiding re-calculating same cosine value

### DIFF
--- a/TypeScript/src/decode.ts
+++ b/TypeScript/src/decode.ts
@@ -98,11 +98,10 @@ const decode = (
       let b = 0;
 
       for (let j = 0; j < numY; j++) {
+        const basisY = Math.cos((Math.PI * y * j) / height);
         for (let i = 0; i < numX; i++) {
-          const basis =
-            Math.cos((Math.PI * x * i) / width) *
-            Math.cos((Math.PI * y * j) / height);
-          let color = colors[i + j * numX];
+          const basis = Math.cos((Math.PI * x * i) / width) * basisY;
+          const color = colors[i + j * numX];
           r += color[0] * basis;
           g += color[1] * basis;
           b += color[2] * basis;


### PR DESCRIPTION
Cos function calucation takes time. This value is the same for every loop. We should use the same value.