### PR TITLE
Add `exports.browser.require`

### DIFF
--- a/TypeScript/package.json
+++ b/TypeScript/package.json
@@ -8,7 +8,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "browser": "./dist/esm/index.js",
+      "browser": {
+        "import":"./dist/esm/index.js",
+        "require": "./dist/index.js"
+      },
       "import": "./dist/index.mjs",
       "module": "./dist/esm/index.js",
       "node": "./dist/index.js",


### PR DESCRIPTION
This will allow tools like Jest – when used in conjunction with `jest-environment-jsdom` – to grab the CommonJS variant of the package when looking for the browser entry point.

This will make whitelisting blurhash in Jest's [`transformIgnorePatterns`](https://jestjs.io/docs/configuration#transformignorepatterns-arraystring) redundant.