### PR TITLE
(Kotlin) Improve decode speed by avoiding re-calculating same cosine value

### DIFF
--- a/Kotlin/lib/src/main/java/com/wolt/blurhashkt/BlurHashDecoder.kt
+++ b/Kotlin/lib/src/main/java/com/wolt/blurhashkt/BlurHashDecoder.kt
@@ -114,9 +114,9 @@ object BlurHashDecoder {
                 var g = 0f
                 var b = 0f
                 for (j in 0 until numCompY) {
+                    val cosY = cosinesY.getCos(calculateCosY, j, numCompY, y, height)
                     for (i in 0 until numCompX) {
                         val cosX = cosinesX.getCos(calculateCosX, i, numCompX, x, width)
-                        val cosY = cosinesY.getCos(calculateCosY, j, numCompY, y, height)
                         val basis = (cosX * cosY).toFloat()
                         val color = colors[j * numCompX + i]
                         r += color[0] * basis


### PR DESCRIPTION
Apply #228 optimization in Kotlin