### PR TITLE
Added Dart impl. in C

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Python"]
 	path = Python
 	url = https://github.com/creditornot/blurhash-python.git
+[submodule "Dart"]
+	path = Dart
+	url = https://github.com/folksable/blurhash_ffi.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "Python"]
 	path = Python
 	url = https://github.com/creditornot/blurhash-python.git
-[submodule "Dart"]
-	path = Dart
-	url = https://github.com/folksable/blurhash_ffi.git

--- a/Readme.md
+++ b/Readme.md
@@ -54,7 +54,8 @@ These cover our use cases, but could probably use polishing, extending and impro
 * [Ruby](https://github.com/Gargron/blurhash) - Encoder implementation in Ruby.
 * [Crystal](https://github.com/Sija/blurhash.cr) - Encoder implementation in pure Crystal.
 * [Elm](https://github.com/WhileTruu/elm-blurhash) - Encoder and decoder in Elm.
-* [Dart](https://github.com/justacid/blurhash-dart) - Encoder and decoder implementation in pure Dart.
+* [Dart](https://github.com/folksable/blurhash_ffi) - Encoder and decoder implementation in C into Dart using dart-ffi.
+* [Pure Dart](https://github.com/justacid/blurhash-dart) - Encoder and decoder implementation in pure Dart.
 * [.NET](https://github.com/MarkusPalcer/blurhash.net) - Encoder and decoder in C#.
 * [JavaScript](https://github.com/Dens49/blurhash-js) - Encoder and decoder implementation in pure JavaScript.
 * [.NET](https://github.com/Bond-009/BlurHashSharp) - Encoder implementation in C#.


### PR DESCRIPTION
Hello Wolt Team.

We have ported the C implementation over to dart through dart:ffi, because the pure dart implementation was very slow and it was causing UI freeze.

Our package [published over on pub.dev](https://pub.dev/packages/blurhash_ffi), fixes that issue with the same api for the developers that previously used [blurhash_dart](https://pub.dev/packages/blurhash_dart) and [flutter_blurhash](https://pub.dev/packages/flutter_blurhash).

you may merge it you think it's a good addition to this repo.