### PR TITLE
Support for RGBA in encode

### DIFF
--- a/C/Readme.md
+++ b/C/Readme.md
@@ -18,7 +18,7 @@ It will be overwritten on the next call into the function, so be careful!
 * `yComponents` - The number of components in the Y direction. Must be between 1 and 9. 3 to 5 is usually a good range for this.
 * `width` - The width in pixels of the supplied image.
 * `height` - The height in pixels of the supplied image.
-* `rgb` - A pointer to the pixel data. This is supplied in RGB order, with 3 bytes per pixels.
+* `rgb` - A pointer to the pixel data. This can either be RGB or RGBA.
 * `bytesPerRow` - The number of bytes per row of the RGB pixel data.
 
 ## Usage as a command-line tool

--- a/C/encode.c
+++ b/C/encode.c
@@ -65,12 +65,14 @@ static float *multiplyBasisFunction(int xComponent, int yComponent, int width, i
 	float r = 0, g = 0, b = 0;
 	float normalisation = (xComponent == 0 && yComponent == 0) ? 1 : 2;
 
+	size_t channels = bytesPerRow / width;
+
 	for(int y = 0; y < height; y++) {
 		for(int x = 0; x < width; x++) {
 			float basis = cosf(M_PI * xComponent * x / width) * cosf(M_PI * yComponent * y / height);
-			r += basis * sRGBToLinear(rgb[3 * x + 0 + y * bytesPerRow]);
-			g += basis * sRGBToLinear(rgb[3 * x + 1 + y * bytesPerRow]);
-			b += basis * sRGBToLinear(rgb[3 * x + 2 + y * bytesPerRow]);
+			r += basis * sRGBToLinear(rgb[channels * x + 0 + y * bytesPerRow]);
+			g += basis * sRGBToLinear(rgb[channels * x + 1 + y * bytesPerRow]);
+			b += basis * sRGBToLinear(rgb[channels * x + 2 + y * bytesPerRow]);
 		}
 	}
 


### PR DESCRIPTION
This may not be your priority, since the last commit that modified C dir was 2 years ago, this pr is adding support for encoding 4-channel RGBA byte arrays for `uint8_t *rgb` param in the `blurHashForPixels` function. 

modifies `multiplyBasisFunction` function to infer number of channels from `bytesPerRow` & `width` params instead of just 3 channels.

this will not affect performance or public API, it just extends with the support for `RGBA` pixel values, assuming the user sets `bytesPerRow` accordingly.

for existing users, assuming they used the correct `bytesPerRow`, it will continue to behave like before, as the `channels` gets equal to 3 as before. 