### PR TITLE
Fix suspected off-by-one error in Swift decoder

### DIFF
--- a/Swift/BlurHashDecode.swift
+++ b/Swift/BlurHashDecode.swift
@@ -38,7 +38,7 @@ extension UIImage {
 
                 for j in 0 ..< numY {
                     for i in 0 ..< numX {
-                        let basis = cos(Float.pi * Float(x) * Float(i) / Float(width)) * cos(Float.pi * Float(y) * Float(j) / Float(height))
+                        let basis = cos(Float.pi * Float(x) * Float(i) / Float(width - 1)) * cos(Float.pi * Float(y) * Float(j) / Float(height - 1))
                         let colour = colours[i + j * numX]
                         r += colour.0 * basis
                         g += colour.1 * basis


### PR DESCRIPTION
I believe I found an off-by-one error in the Swift decoder that was resulting in detail being cropped from the bottom and right edges of the decoded images.

Because the `x` and `y` pixel coordinates are iterated using half-open ranges, their maximum values are one less than `width` and `height`. Therefore I *think* the divisors for calculating the `basis` when iterating over pixels should also be one less.

This isn’t very noticeable when using the recommended 32x32 size, but when using smaller sizes like 8x8, this change makes the BlurHash images line up more closely with their source images.