### PR TITLE
Optimize the Kotlin implementation to double performance

### DIFF
--- a/Kotlin/build.gradle
+++ b/Kotlin/build.gradle
@@ -1,15 +1,15 @@
 
 buildscript {
 
-    ext.kotlin_version = '1.3.72'
+    ext.kotlin_version = '2.0.0'
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:8.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 
@@ -19,11 +19,7 @@ allprojects {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
-}
-
-task clean(type: Delete) {
-    delete rootProject.buildDir
 }

--- a/Kotlin/demo/build.gradle
+++ b/Kotlin/demo/build.gradle
@@ -2,9 +2,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-
-    compileSdk 34
     namespace "com.wolt.blurhashapp"
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.wolt.blurhash"

--- a/Kotlin/demo/build.gradle
+++ b/Kotlin/demo/build.gradle
@@ -1,15 +1,15 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
 
-    compileSdkVersion 29
+    compileSdk 34
+    namespace "com.wolt.blurhashapp"
 
     defaultConfig {
         applicationId "com.wolt.blurhash"
-        minSdkVersion 14
-        targetSdkVersion 29
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
     }
@@ -21,9 +21,16 @@ android {
         }
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlinOptions {
+        jvmTarget = "11"
+    }
 }
 
 dependencies {
-    implementation project(path: ':lib')
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation project(':lib')
+    implementation 'androidx.appcompat:appcompat:1.7.0'
 }

--- a/Kotlin/demo/src/main/AndroidManifest.xml
+++ b/Kotlin/demo/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.wolt.blurhashapp">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"
@@ -9,7 +8,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name="com.wolt.blurhashapp.MainActivity">
+        <activity
+            android:name="com.wolt.blurhashapp.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
+++ b/Kotlin/demo/src/main/java/com/wolt/blurhashapp/MainActivity.kt
@@ -2,34 +2,33 @@ package com.wolt.blurhashapp
 
 import android.graphics.Bitmap
 import android.os.Bundle
-import android.os.SystemClock
+import android.view.View
+import android.widget.EditText
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import com.wolt.blurhashkt.BlurHashDecoder
-import kotlinx.android.synthetic.main.activity_main.*
+import kotlin.time.measureTime
 
 class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        val tvDecode: View = findViewById(R.id.tvDecode)
+        val etInput: EditText = findViewById(R.id.etInput)
+        val ivResult: ImageView = findViewById(R.id.ivResult)
+        val ivResultTime: TextView = findViewById(R.id.ivResultTime)
+
         tvDecode.setOnClickListener {
-            var bitmap: Bitmap? = null
-            val time = timed {
+            val bitmap: Bitmap?
+            val time = measureTime {
                 bitmap = BlurHashDecoder.decode(etInput.text.toString(), 20, 12)
             }
             ivResult.setImageBitmap(bitmap)
-            ivResultTime.text = "Time: $time ms"
+            ivResultTime.text = "Time: ${time.inWholeMilliseconds} ms"
         }
     }
 
 }
-
-/**
- * Executes a function and return the time spent in milliseconds.
- */
-private inline fun timed(function: () -> Unit): Long {
-    val start = SystemClock.elapsedRealtime()
-    function()
-    return SystemClock.elapsedRealtime() - start
-}
-

--- a/Kotlin/gradle.properties
+++ b/Kotlin/gradle.properties
@@ -6,9 +6,8 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-android.enableJetifier=true
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx2048m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/Kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/Kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jul 01 10:02:38 EEST 2019
+#Sun Jul 07 23:57:08 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/Kotlin/lib/build.gradle
+++ b/Kotlin/lib/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-android'
 
 android {
 
-    compileSdkVersion 29
+    compileSdk 34
+    namespace "com.wolt.blurhashkt"
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 29
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 
@@ -22,11 +22,16 @@ android {
         }
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlinOptions {
+        jvmTarget = "11"
+    }
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    androidTestImplementation 'junit:junit:4.13'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test:runner:1.6.1'
 }

--- a/Kotlin/lib/build.gradle
+++ b/Kotlin/lib/build.gradle
@@ -2,9 +2,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-
-    compileSdk 34
     namespace "com.wolt.blurhashkt"
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 21

--- a/Kotlin/lib/src/androidTest/java/com/wolt/blurhashkt/BlurHashDecoderTest.kt
+++ b/Kotlin/lib/src/androidTest/java/com/wolt/blurhashkt/BlurHashDecoderTest.kt
@@ -1,24 +1,15 @@
 package com.wolt.blurhashkt
 
 import android.graphics.Bitmap
-import com.wolt.blurhashkt.BlurHashDecoder.clearCache
 import com.wolt.blurhashkt.BlurHashDecoder.decode
-import junit.framework.Assert.assertTrue
-import org.junit.Before
+import org.junit.Assert.assertArrayEquals
 import org.junit.Test
 import java.nio.ByteBuffer
-import java.util.*
 
 
 class BlurHashDecoderTest {
-    @Before
-    @Throws(Exception::class)
-    fun setUp() {
-        clearCache()
-    }
-
     @Test
-    fun decode_smallImage_cacheEnabled_shouldGetTheSameBitmapInManyRequests() {
+    fun decode_smallImage_shouldGetTheSameBitmapInManyRequests() {
         val bmp1 = decode("LEHV6nWB2yk8pyo0adR*.7kCMdnj", 20, 12)!!
         val bmp2 = decode("LEHV6nWB2yk8pyo0adR*.7kCMdnj", 20, 12)!!
         val bmp3 = decode("LEHV6nWB2yk8pyo0adR*.7kCMdnj", 20, 12)!!
@@ -28,50 +19,10 @@ class BlurHashDecoderTest {
     }
 
     @Test
-    fun decode_smallImage_differentCache_shouldGetTheSameBitmapInManyRequests() {
-        val bmp1 = decode("LEHV6nWB2yk8pyo0adR*.7kCMdnj", 20, 12)!!
-        val bmp2 = decode("LEHV6nWB2yk8pyo0adR*.7kCMdnj", 20, 12, useCache = false)!!
-        val bmp3 = decode("LEHV6nWB2yk8pyo0adR*.7kCMdnj", 20, 12)!!
-
-        bmp1.assertEquals(bmp2)
-        bmp2.assertEquals(bmp3)
-    }
-
-    @Test
-    fun decode_smallImage_cacheDisabled_shouldGetTheSameBitmapInManyRequests() {
-        val bmp1 = decode("LEHV6nWB2yk8pyo0adR*.7kCMdnj", 20, 12, useCache = false)!!
-        val bmp2 = decode("LEHV6nWB2yk8pyo0adR*.7kCMdnj", 20, 12, useCache = false)!!
-        val bmp3 = decode("LEHV6nWB2yk8pyo0adR*.7kCMdnj", 20, 12, useCache = false)!!
-
-        bmp1.assertEquals(bmp2)
-        bmp2.assertEquals(bmp3)
-    }
-
-    @Test
-    fun decode_bigImage_cacheEnabled_shouldGetTheSameBitmapInManyRequests() {
+    fun decode_bigImage_shouldGetTheSameBitmapInManyRequests() {
         val bmp1 = decode("LEHV6nWB2yk8pyo0adR*.7kCMdnj", 100, 100)!!
         val bmp2 = decode("LEHV6nWB2yk8pyo0adR*.7kCMdnj", 100, 100)!!
         val bmp3 = decode("LEHV6nWB2yk8pyo0adR*.7kCMdnj", 100, 100)!!
-
-        bmp1.assertEquals(bmp2)
-        bmp2.assertEquals(bmp3)
-    }
-
-    @Test
-    fun decode_bigImage_differentCache_shouldGetTheSameBitmapInManyRequests() {
-        val bmp1 = decode("LEHV6nWB2yk8pyo0adR*.7kCMdnj", 100, 100)!!
-        val bmp2 = decode("LEHV6nWB2yk8pyo0adR*.7kCMdnj", 100, 100, useCache = false)!!
-        val bmp3 = decode("LEHV6nWB2yk8pyo0adR*.7kCMdnj", 100, 100)!!
-
-        bmp1.assertEquals(bmp2)
-        bmp2.assertEquals(bmp3)
-    }
-
-    @Test
-    fun decode_bigImage_cacheDisabled_shouldGetTheSameBitmapInManyRequests() {
-        val bmp1 = decode("LEHV6nWB2yk8pyo0adR*.7kCMdnj", 100, 100, useCache = false)!!
-        val bmp2 = decode("LEHV6nWB2yk8pyo0adR*.7kCMdnj", 100, 100, useCache = false)!!
-        val bmp3 = decode("LEHV6nWB2yk8pyo0adR*.7kCMdnj", 100, 100, useCache = false)!!
 
         bmp1.assertEquals(bmp2)
         bmp2.assertEquals(bmp3)
@@ -83,6 +34,5 @@ fun Bitmap.assertEquals(bitmap2: Bitmap) {
     copyPixelsToBuffer(buffer1)
     val buffer2: ByteBuffer = ByteBuffer.allocate(bitmap2.height * bitmap2.rowBytes)
     bitmap2.copyPixelsToBuffer(buffer2)
-    val equals = Arrays.equals(buffer1.array(), buffer2.array())
-    assertTrue(equals)
+    assertArrayEquals(buffer1.array(), buffer2.array())
 }

--- a/Kotlin/lib/src/main/AndroidManifest.xml
+++ b/Kotlin/lib/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="com.wolt.blurhashkt" />

--- a/Kotlin/lib/src/main/java/com/wolt/blurhashkt/BlurHashDecoder.kt
+++ b/Kotlin/lib/src/main/java/com/wolt/blurhashkt/BlurHashDecoder.kt
@@ -2,64 +2,44 @@ package com.wolt.blurhashkt
 
 import android.graphics.Bitmap
 import android.graphics.Color
+import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.pow
 import kotlin.math.withSign
 
 object BlurHashDecoder {
 
-    // cache Math.cos() calculations to improve performance.
-    // The number of calculations can be huge for many bitmaps: width * height * numCompX * numCompY * 2 * nBitmaps
-    // the cache is enabled by default, it is recommended to disable it only when just a few images are displayed
-    private val cacheCosinesX = HashMap<Int, DoubleArray>()
-    private val cacheCosinesY = HashMap<Int, DoubleArray>()
-
-    /**
-     * Clear calculations stored in memory cache.
-     * The cache is not big, but will increase when many image sizes are used,
-     * if the app needs memory it is recommended to clear it.
-     */
-    fun clearCache() {
-        cacheCosinesX.clear()
-        cacheCosinesY.clear()
-    }
-
     /**
      * Decode a blur hash into a new bitmap.
-     *
-     * @param useCache use in memory cache for the calculated math, reused by images with same size.
-     *                 if the cache does not exist yet it will be created and populated with new calculations.
-     *                 By default it is true.
      */
-    fun decode(blurHash: String?, width: Int, height: Int, punch: Float = 1f, useCache: Boolean = true): Bitmap? {
+    fun decode(blurHash: String?, width: Int, height: Int, punch: Float = 1f): Bitmap? {
         if (blurHash == null || blurHash.length < 6) {
             return null
         }
         val numCompEnc = decode83(blurHash, 0, 1)
         val numCompX = (numCompEnc % 9) + 1
         val numCompY = (numCompEnc / 9) + 1
-        if (blurHash.length != 4 + 2 * numCompX * numCompY) {
+        val totalComp = numCompX * numCompY
+        if (blurHash.length != 4 + 2 * totalComp) {
             return null
         }
         val maxAcEnc = decode83(blurHash, 1, 2)
         val maxAc = (maxAcEnc + 1) / 166f
-        val colors = Array(numCompX * numCompY) { i ->
-            if (i == 0) {
-                val colorEnc = decode83(blurHash, 2, 6)
-                decodeDc(colorEnc)
-            } else {
-                val from = 4 + i * 2
-                val colorEnc = decode83(blurHash, from, from + 2)
-                decodeAc(colorEnc, maxAc * punch)
-            }
+        val colors = FloatArray(totalComp * 3)
+        var colorEnc = decode83(blurHash, 2, 6)
+        decodeDc(colorEnc, colors)
+        for (i in 1 until totalComp) {
+            val from = 4 + i * 2
+            colorEnc = decode83(blurHash, from, from + 2)
+            decodeAc(colorEnc, maxAc * punch, colors, i * 3)
         }
-        return composeBitmap(width, height, numCompX, numCompY, colors, useCache)
+        return composeBitmap(width, height, numCompX, numCompY, colors)
     }
 
-    private fun decode83(str: String, from: Int = 0, to: Int = str.length): Int {
+    private fun decode83(str: String, from: Int, to: Int): Int {
         var result = 0
         for (i in from until to) {
-            val index = charMap[str[i]] ?: -1
+            val index = CHARS.indexOf(str[i])
             if (index != -1) {
                 result = result * 83 + index
             }
@@ -67,11 +47,13 @@ object BlurHashDecoder {
         return result
     }
 
-    private fun decodeDc(colorEnc: Int): FloatArray {
-        val r = colorEnc shr 16
-        val g = (colorEnc shr 8) and 255
-        val b = colorEnc and 255
-        return floatArrayOf(srgbToLinear(r), srgbToLinear(g), srgbToLinear(b))
+    private fun decodeDc(colorEnc: Int, outArray: FloatArray) {
+        val r = (colorEnc shr 16) and 0xFF
+        val g = (colorEnc shr 8) and 0xFF
+        val b = colorEnc and 0xFF
+        outArray[0] = srgbToLinear(r)
+        outArray[1] = srgbToLinear(g)
+        outArray[2] = srgbToLinear(b)
     }
 
     private fun srgbToLinear(colorEnc: Int): Float {
@@ -83,84 +65,57 @@ object BlurHashDecoder {
         }
     }
 
-    private fun decodeAc(value: Int, maxAc: Float): FloatArray {
+    private fun decodeAc(value: Int, maxAc: Float, outArray: FloatArray, outIndex: Int) {
         val r = value / (19 * 19)
         val g = (value / 19) % 19
         val b = value % 19
-        return floatArrayOf(
-                signedPow2((r - 9) / 9.0f) * maxAc,
-                signedPow2((g - 9) / 9.0f) * maxAc,
-                signedPow2((b - 9) / 9.0f) * maxAc
-        )
+        outArray[outIndex] = signedPow2((r - 9) / 9.0f) * maxAc
+        outArray[outIndex + 1] = signedPow2((g - 9) / 9.0f) * maxAc
+        outArray[outIndex + 2] = signedPow2((b - 9) / 9.0f) * maxAc
     }
 
-    private fun signedPow2(value: Float) = value.pow(2f).withSign(value)
+    private fun signedPow2(value: Float) = (value * value).withSign(value)
 
     private fun composeBitmap(
-            width: Int, height: Int,
-            numCompX: Int, numCompY: Int,
-            colors: Array<FloatArray>,
-            useCache: Boolean
+        width: Int, height: Int,
+        numCompX: Int, numCompY: Int,
+        colors: FloatArray
     ): Bitmap {
         // use an array for better performance when writing pixel colors
         val imageArray = IntArray(width * height)
-        val calculateCosX = !useCache || !cacheCosinesX.containsKey(width * numCompX)
-        val cosinesX = getArrayForCosinesX(calculateCosX, width, numCompX)
-        val calculateCosY = !useCache || !cacheCosinesY.containsKey(height * numCompY)
-        val cosinesY = getArrayForCosinesY(calculateCosY, height, numCompY)
+        val cosinesX = createCosines(width, numCompX)
+        val cosinesY = if (width == height && numCompX == numCompY) {
+            cosinesX
+        } else {
+            createCosines(height, numCompY)
+        }
         for (y in 0 until height) {
             for (x in 0 until width) {
                 var r = 0f
                 var g = 0f
                 var b = 0f
                 for (j in 0 until numCompY) {
+                    val cosY = cosinesY[y * numCompY + j]
                     for (i in 0 until numCompX) {
-                        val cosX = cosinesX.getCos(calculateCosX, i, numCompX, x, width)
-                        val cosY = cosinesY.getCos(calculateCosY, j, numCompY, y, height)
-                        val basis = (cosX * cosY).toFloat()
-                        val color = colors[j * numCompX + i]
-                        r += color[0] * basis
-                        g += color[1] * basis
-                        b += color[2] * basis
+                        val cosX = cosinesX[x * numCompX + i]
+                        val basis = cosX * cosY
+                        val colorIndex = (j * numCompX + i) * 3
+                        r += colors[colorIndex] * basis
+                        g += colors[colorIndex + 1] * basis
+                        b += colors[colorIndex + 2] * basis
                     }
                 }
-                imageArray[x + width * y] = Color.rgb(linearToSrgb(r), linearToSrgb(g), linearToSrgb(b))
+                imageArray[x + width * y] =
+                    Color.rgb(linearToSrgb(r), linearToSrgb(g), linearToSrgb(b))
             }
         }
         return Bitmap.createBitmap(imageArray, width, height, Bitmap.Config.ARGB_8888)
     }
 
-    private fun getArrayForCosinesY(calculate: Boolean, height: Int, numCompY: Int) = when {
-        calculate -> {
-            DoubleArray(height * numCompY).also {
-                cacheCosinesY[height * numCompY] = it
-            }
-        }
-        else -> {
-            cacheCosinesY[height * numCompY]!!
-        }
-    }
-
-    private fun getArrayForCosinesX(calculate: Boolean, width: Int, numCompX: Int) = when {
-        calculate -> {
-            DoubleArray(width * numCompX).also {
-                cacheCosinesX[width * numCompX] = it
-            }
-        }
-        else -> cacheCosinesX[width * numCompX]!!
-    }
-
-    private fun DoubleArray.getCos(
-            calculate: Boolean,
-            x: Int,
-            numComp: Int,
-            y: Int,
-            size: Int
-    ): Double {
-        if (calculate) {
-            this[x + numComp * y] = cos(Math.PI * y * x / size)
-        }
-        return this[x + numComp * y]
+    private fun createCosines(size: Int, numComp: Int) = FloatArray(size * numComp) { index ->
+        val x = index / numComp
+        val i = index % numComp
+        cos(PI * x * i / size).toFloat()
     }
 
     private fun linearToSrgb(value: Float): Int {
@@ -172,14 +127,5 @@ object BlurHashDecoder {
         }
     }
 
-    private val charMap = listOf(
-            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G',
-            'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
-            'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o',
-            'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '#', '$', '%', '*', '+', ',',
-            '-', '.', ':', ';', '=', '?', '@', '[', ']', '^', '_', '{', '|', '}', '~'
-    )
-            .mapIndexed { i, c -> c to i }
-            .toMap()
-
+    private const val CHARS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz#$%*+,-.:;=?@[]^_{|}~"
 }


### PR DESCRIPTION
## BlurHashDecoder optimizations

- Precompute cosines tables before composing the image so each cosine value is only computed once.
- Cosines are stored as Float instead of stored as Double and transformed to Float after multiplication.
- Compute cosines tables once if both are identical (for square images with the same number of colors in both dimensions).
- Store colors in a one-dimension array instead of a two-dimension array to reduce memory allocations.
- Use a simple `String.indexOf()` to find the index of a Base83 char, which is both faster and needs less memory than a `HashMap` thanks to better locality and no boxing of chars.
- Replace `value.pow(2f)` with faster `value * value`
- No cache is used, so computations may be performed in parallel on background threads without the need for synchronization which limits throughput.

## Problems with the old cache

The old implementation used a cache that had 3 issues that evaded the tests:
- Access to the cache was not synchronized, thus two concurrent calls on different threads could result in cache corruption or reading incorrect values from a half-filled array. Since Blurhash is an expensive computation, the main use case is to call it from a pooled background thread.
- The cache key was the image dimension (width or height) multiplied by the number of colors in that dimension. This means the cache will hit the same result for an image width of 32 pixels with 8 colors (256) or 64 pixels with 4 colors (also 256) but this is incorrect because even if the array size for these configurations is the same and contains the same values, these values appear in a different order. The cache will thus return incorrect values for one of the two configurations. The correct cache key to avoid collisions would have been something like `(width * 10) + [number of colors]`, where 10 is the max colors number.
- Even when the cache was disabled (`useCache` is false), the code still allocated memory but didn't write to it. This had two bad effects:
  1. Memory was wasted.
  2. Worse: when the blurhash method was called two times in a row for a compatible configuration, first with the cache disabled then with the cache enabled, the second call will hit the cache but read empty values, resulting in an incorrect computation.

Fixing and keeping the cosines cache would not improve the single-threading performance much, but would make the throughput lower for multi-threading performance because of synchronization. Thus it makes more sense to just **remove the cache** completely, now that the algorithm is faster without cache than it was before with the cache.

## Benchmarks

Simple: 4x4 colors, 32x32 pixels output.
Complex: 9x9 colors, 256x256 pixels output.

**Pixel 7 (Android 14)**

```
      517 662   ns          27 allocs    Trace    BlurHashDecoderBenchmark.originalSimpleNoCache
      225 079   ns          27 allocs    Trace    BlurHashDecoderBenchmark.originalSimpleWithCache
      108 153   ns           8 allocs    Trace    BlurHashDecoderBenchmark.newSimple

  162 140 992   ns          92 allocs    Trace    BlurHashDecoderBenchmark.originalComplexNoCache
   46 720 337   ns          92 allocs    Trace    BlurHashDecoderBenchmark.originalComplexWithCache
   13 124 883   ns           8 allocs    Trace    BlurHashDecoderBenchmark.newComplex
```

**Nexus 5 (Android 6)**

```
    6 389 579   ns          26 allocs    Trace    BlurHashDecoderBenchmark.originalSimpleNoCache
    2 358 534   ns          26 allocs    Trace    BlurHashDecoderBenchmark.originalSimpleWithCache
    1 546 684   ns           7 allocs    Trace    BlurHashDecoderBenchmark.newSimple

2 258 036 875   ns          91 allocs    Trace    BlurHashDecoderBenchmark.originalComplexNoCache
  404 196 250   ns          91 allocs    Trace    BlurHashDecoderBenchmark.originalComplexWithCache
  185 823 959   ns           7 allocs    Trace    BlurHashDecoderBenchmark.newComplex
```

The source code of the benchmark can be found [here](https://github.com/cbeyls/BlurHashAndroidBenchmark).

## Other code changes

- Replace custom function `timed()` with standard `measureTime()` in demo app
- Replace `junit.framework.Assert.assertTrue` with `org.junit.Assert.assertArrayEquals`.

## Update configuration to modern standards
(So the project can build on modern versions of Android Studio)

- Upgrade dependencies: Kotlin 2.0.0, AppCompat 1.7.0, Androidx Test Runner 1.6.1, JUnit 4.13.2, Android Gradle Plugin 8.5.0, Gradle 8.7.0
- Bump `minSdkVersion` to 21 and `targetSdkVersion` to 34
- Replace abandoned **jcenter** repository with **mavenCentral**
- Add `namespace` to replace `package` in `AndroidManifest.xml`
- Target Java 11 bytecode
- Remove obsolete Kotlin Android Extensions plugin
- Disable Jetifier.