### PR TITLE
Speedup C encoder up to 100x

### DIFF
--- a/C/Makefile
+++ b/C/Makefile
@@ -1,12 +1,18 @@
 PROGRAM=blurhash_encoder
 DECODER=blurhash_decoder
-$(PROGRAM): encode_stb.c encode.c encode.h stb_image.h common.h
-	$(CC) -o $@ encode_stb.c encode.c -lm -Ofast -Wall
 
-$(DECODER): decode_stb.c decode.c decode.h stb_writer.h common.h
-	$(CC) -o $(DECODER) decode_stb.c decode.c -lm -Ofast -Wall
+encod%.o: encod%.c encode.h stb_image.h common.h
+	$(CC) -c $< -o $@ -Ofast -Wall
+$(PROGRAM): encode_stb.o encode.o
+	$(CC) -o $@ encode_stb.o encode.o -lm
+
+decod%.o: decod%.c decode.h stb_writer.h common.h
+	$(CC) -c $< -o $@ -Ofast -Wall
+$(DECODER): decode_stb.o decode.o
+	$(CC) -o $@ decode_stb.o decode.o -lm
 
 .PHONY: clean
 clean:
 	rm -f $(PROGRAM)
 	rm -f $(DECODER)
+	rm -f *.o

--- a/C/Makefile
+++ b/C/Makefile
@@ -1,10 +1,10 @@
 PROGRAM=blurhash_encoder
 DECODER=blurhash_decoder
 $(PROGRAM): encode_stb.c encode.c encode.h stb_image.h common.h
-	$(CC) -o $@ encode_stb.c encode.c -lm -Ofast
+	$(CC) -o $@ encode_stb.c encode.c -lm -Ofast -Wall
 
 $(DECODER): decode_stb.c decode.c decode.h stb_writer.h common.h
-	$(CC) -o $(DECODER) decode_stb.c decode.c -lm -Ofast
+	$(CC) -o $(DECODER) decode_stb.c decode.c -lm -Ofast -Wall
 
 .PHONY: clean
 clean:

--- a/C/common.h
+++ b/C/common.h
@@ -1,11 +1,8 @@
 #ifndef __BLURHASH_COMMON_H__
 #define __BLURHASH_COMMON_H__
 
-#include<math.h>
-
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
+#define _USE_MATH_DEFINES
+#include <math.h>
 
 static inline int linearTosRGB(float value) {
 	float v = fmaxf(0, fminf(1, value));

--- a/C/encode.c
+++ b/C/encode.c
@@ -3,7 +3,9 @@
 
 #include <string.h>
 
-static float *multiplyBasisFunction(int xComponent, int yComponent, int width, int height, uint8_t *rgb, size_t bytesPerRow);
+static float *multiplyBasisFunction(
+	int xComponent, int yComponent, int width, int height, uint8_t *rgb, size_t bytesPerRow,
+	float *cosX);
 static char *encode_int(int value, int length, char *destination);
 
 static int encodeDC(float r, float g, float b);
@@ -32,14 +34,17 @@ const char *blurHashForPixels(int xComponents, int yComponents, int width, int h
 
 	init_sRGBToLinear_cache();
 
+	float *cosX = (float *)malloc(sizeof(float) * width);
+	if (! cosX) return NULL;
 	for(int y = 0; y < yComponents; y++) {
 		for(int x = 0; x < xComponents; x++) {
-			float *factor = multiplyBasisFunction(x, y, width, height, rgb, bytesPerRow);
+			float *factor = multiplyBasisFunction(x, y, width, height, rgb, bytesPerRow, cosX);
 			factors[y][x][0] = factor[0];
 			factors[y][x][1] = factor[1];
 			factors[y][x][2] = factor[2];
 		}
 	}
+	free(cosX);
 
 	float *dc = factors[0][0];
 	float *ac = dc + 3;
@@ -75,16 +80,25 @@ const char *blurHashForPixels(int xComponents, int yComponents, int width, int h
 	return buffer;
 }
 
-static float *multiplyBasisFunction(int xComponent, int yComponent, int width, int height, uint8_t *rgb, size_t bytesPerRow) {
+static float *multiplyBasisFunction(
+	int xComponent, int yComponent, int width, int height, uint8_t *rgb, size_t bytesPerRow,
+	float *cosX
+) {
 	float r = 0, g = 0, b = 0;
 	float normalisation = (xComponent == 0 && yComponent == 0) ? 1 : 2;
 
+	for(int x = 0; x < width; x++) {
+		cosX[x] = cosf(M_PI * xComponent * x / width);
+	}
+
 	for(int y = 0; y < height; y++) {
+		uint8_t *src = rgb + y * bytesPerRow;
+		float cosY = cosf(M_PI * yComponent * y / height);
 		for(int x = 0; x < width; x++) {
-			float basis = cosf(M_PI * xComponent * x / width) * cosf(M_PI * yComponent * y / height);
-			r += basis * sRGBToLinear_cache[rgb[3 * x + 0 + y * bytesPerRow]];
-			g += basis * sRGBToLinear_cache[rgb[3 * x + 1 + y * bytesPerRow]];
-			b += basis * sRGBToLinear_cache[rgb[3 * x + 2 + y * bytesPerRow]];
+			float basis = cosX[x] * cosY;
+			r += basis * sRGBToLinear_cache[src[3 * x + 0]];
+			g += basis * sRGBToLinear_cache[src[3 * x + 1]];
+			b += basis * sRGBToLinear_cache[src[3 * x + 2]];
 		}
 	}
 

--- a/C/encode_stb.c
+++ b/C/encode_stb.c
@@ -15,8 +15,8 @@ int main(int argc, const char **argv) {
 
 	int xComponents = atoi(argv[1]);
 	int yComponents = atoi(argv[2]);
-	if(xComponents < 1 || xComponents > 8 || yComponents < 1 || yComponents > 8) {
-		fprintf(stderr, "Component counts must be between 1 and 8.\n");
+	if(xComponents < 1 || xComponents > 9 || yComponents < 1 || yComponents > 9) {
+		fprintf(stderr, "Component counts must be between 1 and 9.\n");
 		return 1;
 	}
 


### PR DESCRIPTION
All changes are divided by independent commits, some of them are optional.

In addition to improving performance there are changes:

* Do not define `M_PI` in sources, ensure it defined in `math.h`.
* Fixed max number of components for `blurhash_encoder` executable (in line with `blurHashForPixels` function)
* Improved `Makefile` to avoid heavy `encode_stb` recompilation on each change.

Benchmarks are in [the comment](https://github.com/woltapp/blurhash/pull/256#issuecomment-2392294035).
